### PR TITLE
update eslint-plugin-import

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ---
 
+## [Unreleased] 2023-01-12
+
+### Fixed
+
+- Update eslint-plugin-import after some release thrash
+
 ## [2.1.0] 2023-01-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "dependencies": {
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-fp": "^2.3.0",
-    "eslint-plugin-import": "^2.26.0"
+    "eslint-plugin-import": "^2.27.4"
   },
   "peerDependencies": {
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-fp": "^2.3.0",
-    "eslint-plugin-import": "^2.25.1"
+    "eslint-plugin-import": "^2.27.4"
   },
   "devDependencies": {
     "eslint": "^8.31.0"


### PR DESCRIPTION
there was some scrambled releases around v2.27 but it seems to be ironed out at 2.27.4 

previous versions would cause an `eslint` command to fail

https://www.npmjs.com/package/eslint-plugin-import?activeTab=versions