### PR TITLE
parserOptions.ecmaVersion = 12 // 2021

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ let off = 'off'
 let err = 'error'
 module.exports = {
   parserOptions: {
-    ecmaVersion: 11 // 2020
+    ecmaVersion: 12 // 2021
   },
   // parserOptions default source type is `script`; override to `module` because eslint bailed on #12675
   overrides: [ {


### PR DESCRIPTION
Node 16 is our oldest supported version of Node until AWS Lambda stops supporting it.

node.green shows 100% compatibility between Node v16 and ES12 (2021):  
https://node.green/#ES2021

the big change will be allowing these assignment operators

<img width="329" alt="image" src="https://github.com/architect/eslint-config/assets/15697/ea71d2d9-74da-4f26-bd6d-60b1e204ca63">
